### PR TITLE
Fix application of a bad caching policy for LFBs.

### DIFF
--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -575,7 +575,6 @@ static irqreturn_t xenfb2_event_handler(int rq, void *priv)
             xenfb2_update_fb2m(info, event->update_fb2m.start, event->update_fb2m.end);
             break;
         case XENFB2_TYPE_UPDATE_DIRTY:
-            info->cache_attr = _PAGE_CACHE_WB;
             xenfb2_update_dirty(info);
             break;
         case XENFB2_TYPE_FB_CACHING:


### PR DESCRIPTION
For an unknown reason, the xenfb framebuffer is being forced into
writeback mode each time we query the dirty rectangles. This introduces
a cache incoherency with our i915 zero-copy foreign mappings.

Signed-off-by: Kyle J. Temkin temkink@ainfosec.com
