### PR TITLE
Missing header & gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+linux/.tmp_versions
+linux/.*.cmd
+linux/*.symvers
+linux/*.order
+linux/*.ko
+linux/*.mod.c
+linux/*.o

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -24,6 +24,7 @@
 #include <linux/fb.h>
 #include <xen/interface/io/protocols.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
 #include <asm/xen/page.h>


### PR DESCRIPTION
Include header linux/vmalloc.h since vmalloc/vfree are used. The header is not included implicitly for later Linux versions, and we should not rely on that anyway.

Also add a gitignore for convenience.
