### PR TITLE
RFC: OXT-1579: Remove deprecated interfaces in xenfb2 and refactor.

### DIFF
--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -384,20 +384,23 @@ static int xenfb2_setcolreg(unsigned regno, unsigned red, unsigned green,
     if (regno > info->cmap.len)
         return 1;
 
-    red >>= (16 - info->var.red.length);
-    green >>= (16 - info->var.green.length);
-    blue >>= (16 - info->var.blue.length);
+#define CNVT_TOHW(val, width) ((((val)<<(width))+0x7FFF-(val))>>16)
+    red = CNVT_TOHW(red, info->var.red.length);
+    green = CNVT_TOHW(green, info->var.green.length);
+    blue = CNVT_TOHW(blue, info->var.blue.length);
+    transp = CNVT_TOHW(transp, info->var.transp.length);
+#undef CNVT_TOHW
 
     v = (red << info->var.red.offset) |
         (green << info->var.green.offset) |
         (blue << info->var.blue.offset);
 
     switch (info->var.bits_per_pixel) {
-    case 16:
-    case 24:
-    case 32:
-	((u32 *)info->pseudo_palette)[regno] = v;
-	break;
+        case 16:
+        case 24:
+        case 32:
+            ((u32 *)info->pseudo_palette)[regno] = v;
+            break;
     }
 
     return 0;

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -222,9 +222,9 @@ static int xenfb2_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
     struct xenfb2_mapping *map = vma->vm_private_data;
     struct xenfb2_info *info = map->info;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
-    int pgnr = ((long)vmf->address - vma->vm_start) >> PAGE_SHIFT;
+    int pgnr = (vmf->address - vma->vm_start) >> PAGE_SHIFT;
 #else
-    int pgnr = ((long)vmf->virtual_address - vma->vm_start) >> PAGE_SHIFT;
+    int pgnr = (vmf->virtual_address - vma->vm_start) >> PAGE_SHIFT;
 #endif
     struct page *page;
 

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -20,7 +20,6 @@
 #include <linux/console.h>
 #include <linux/freezer.h>
 #include <xen/xenbus.h>
-#include <linux/kthread.h>
 #include <linux/fb.h>
 #include <xen/interface/io/protocols.h>
 #include <linux/version.h>
@@ -77,11 +76,6 @@ struct xenfb2_info
     int                         fb2m_npages;
     unsigned long               *fb2m;
 
-    unsigned long               *dirty_bitmap;
-    unsigned long               *shadow_bitmap;
-#define BITMAP_LEN(info) \
-    (((info)->fb_npages + BITS_PER_LONG - 1) / BITS_PER_LONG)
-
     struct list_head            mappings;
     struct mutex                mm_lock;
 
@@ -91,7 +85,6 @@ struct xenfb2_info
     unsigned long               cache_attr;
 #endif
     wait_queue_head_t           thread_wq;
-    struct task_struct          *kthread;
     unsigned long               thread_flags;
 
     wait_queue_head_t           checkvar_wait;
@@ -257,24 +250,6 @@ static int xenfb2_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 
     vmf->page = page;
 
-    /*
-     * Julian & Eric:
-     *
-     * Xorg may issue read accesses before actually writing on the
-     * framebuffer. Thus, subsequent write accesses on the same pages
-     * may not be trapped and reported properly in the dirty bitmap because
-     * the page is already mapped.
-     *
-     * We fix that by marking the page as dirty even for read accesses.
-     */
-#if 0
-    if (vmf->flags & FAULT_FLAG_WRITE) {
-        set_bit(pgnr % BITS_PER_LONG,
-                &info->shadow_bitmap[pgnr / BITS_PER_LONG]);
-    }
-#endif
-    set_bit(pgnr, &info->shadow_bitmap[0]);
-
     return 0;
 }
 
@@ -319,12 +294,8 @@ static int xenfb2_mmap(struct fb_info *fb_info, struct vm_area_struct *vma)
 #else
     vma->vm_flags |= (VM_DONTEXPAND | VM_RESERVED);
 #endif
-    vma->vm_private_data = map;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0))
-    vma->vm_page_prot = __pgprot((pgprot_val(vma->vm_page_prot) &
-                                  ~_PAGE_CACHE_MASK) | info->cache_attr);
-#endif
+    vma->vm_private_data = map;
 
     return 0;
 }
@@ -450,15 +421,10 @@ static void xenfb2_copyarea(struct fb_info *p, const struct fb_copyarea *area)
 static int xenfb2_release(struct fb_info *fb_info, int user)
 {
     struct xenfb2_info *info = fb_info->par;
-    unsigned int i;
 
-    if (info && info->fb) {
+    if (info && info->fb)
         memset(info->fb, 0, info->fb_size);
 
-        /* Update dirty bitmap */
-        for (i = 0; i < BITMAP_LEN(info); i++)
-            info->shadow_bitmap[i] = ~0;
-    }
     return 0;
 }
 
@@ -473,51 +439,6 @@ static struct fb_ops xenfb2_fb_ops = {
     .fb_set_par     = xenfb2_set_par,
     .fb_release     = xenfb2_release,
 };
-
-static int xenfb2_thread(void *data)
-{
-    struct xenfb2_info *info = (void *)data;
-    struct xenfb2_mapping *map;
-    unsigned long i;
-
-    wait_event_interruptible(info->thread_wq, kthread_should_stop() ||
-                             test_and_clear_bit(0, &info->thread_flags));
-    try_to_freeze();
-
-    while (!kthread_should_stop()) {
-        union xenfb2_out_event evt;
-
-        mutex_lock(&info->mm_lock);
-        list_for_each_entry(map, &info->mappings, link) {
-            struct vm_area_struct *vma = map->vma;
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
-            zap_page_range(vma, vma->vm_start, vma->vm_end - vma->vm_start);
-#else
-            zap_page_range(vma, vma->vm_start, vma->vm_end - vma->vm_start, NULL);
-#endif
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0))
-            vma->vm_page_prot = __pgprot((pgprot_val(vma->vm_page_prot) &
-                                          ~_PAGE_CACHE_MASK) | info->cache_attr);
-#endif
-        }
-        mutex_unlock(&info->mm_lock);
-
-        /* Atomically copy shadow_bitmap to dirty bitmap and clear it */
-        for (i = 0; i < BITMAP_LEN(info); i++)
-            info->dirty_bitmap[i] = xchg(&info->shadow_bitmap[i], 0);
-
-        /* Send event */
-        evt.type = XENFB2_TYPE_DIRTY_READY;
-        xenfb2_send_event(info, (union xenfb2_out_event *)&evt);
-
-        wait_event_interruptible(info->thread_wq, kthread_should_stop() ||
-                                 test_and_clear_bit(0, &info->thread_flags));
-        try_to_freeze();
-    }
-
-    return 0;
-}
 
 static void xenfb2_update_dirty(struct xenfb2_info *info)
 {
@@ -736,7 +657,6 @@ xenfb2_probe(struct xenbus_device *dev,
     struct xenfb2_info *info;
     struct fb_info *fb_info;
     int ret = 0;
-    int i;
 
     info = kzalloc(sizeof (*info), GFP_KERNEL);
     if (!info) {
@@ -757,7 +677,6 @@ xenfb2_probe(struct xenbus_device *dev,
 
     info->thread_flags = 0;
     init_waitqueue_head(&info->thread_wq);
-    info->kthread = kthread_run(xenfb2_thread, info, "xenfb2 thread");
 
     xenfb2_backend_read_params(dev, info);
 
@@ -778,18 +697,6 @@ xenfb2_probe(struct xenbus_device *dev,
     info->fb2m = vmalloc(info->fb_npages * sizeof (unsigned long *));
     if (!info->fb2m)
         goto fail_nomem;
-
-    /* Shouldn't take more than 1 page */
-    info->dirty_bitmap = vmalloc(BITMAP_LEN(info) * sizeof (unsigned long));
-    if (!info->dirty_bitmap)
-        goto fail_nomem;
-    info->shadow_bitmap = kmalloc(BITMAP_LEN(info) * sizeof (unsigned long),
-                                  GFP_KERNEL);
-    if (!info->shadow_bitmap)
-        goto fail_nomem;
-
-    for (i = 0; i < BITMAP_LEN(info); i++)
-        info->shadow_bitmap[i] = ~0;
 
     info->shared_page = (void *)__get_free_page(GFP_KERNEL | __GFP_ZERO);
     if (!info->shared_page)
@@ -893,12 +800,6 @@ static int xenfb2_remove(struct xenbus_device *dev)
         kfree(info->fb_pages);
     if (info->fb)
         vfree(info->fb);
-    if (info->dirty_bitmap)
-        vfree(info->dirty_bitmap);
-    if (info->shadow_bitmap)
-        kfree(info->shadow_bitmap);
-    if (info->kthread)
-        kthread_stop(info->kthread);
 
     kfree(info);
 
@@ -950,8 +851,6 @@ static void xenfb2_init_shared_page(struct xenfb2_info *info,
          */
         spage->fb2m[i] = mfn;
     }
-
-    spage->dirty_bitmap_page = vmalloc_to_mfn((char *)info->dirty_bitmap);
 }
 
 static void xenfb2_backend_changed(struct xenbus_device *dev,

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -30,6 +30,7 @@
 #include <asm/xen/page.h>
 #include <xen/events.h>
 #include <xen/page.h>
+#include <xen/platform_pci.h>
 #else
 #include <linux/mm.h>
 #include <asm/page.h>
@@ -1077,20 +1078,14 @@ static struct xenbus_driver xenfb2_driver = {
 
 static int __init xenfb2_init(void)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
-    if (!xen_pv_domain())
-#else
-    if (!is_running_on_xen())
-#endif
+    if (!xen_domain())
         return -ENODEV;
 
-    /* Nothing to do if running in dom0. */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
     if (xen_initial_domain())
-#else
-    if (is_initial_xendomain())
-#endif
-	return -ENODEV;
+        return -ENODEV;
+
+    if (!xen_has_pv_devices())
+        return -ENODEV;
 
     return xenbus_register_frontend(&xenfb2_driver);
 }

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -29,6 +29,7 @@
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
 #include <asm/xen/page.h>
 #include <xen/events.h>
+#include <xen/page.h>
 #else
 #include <linux/mm.h>
 #include <asm/page.h>
@@ -533,7 +534,7 @@ static void xenfb2_update_fb2m(struct xenfb2_info *info, unsigned int start,
 
     for (pagenr = start; pagenr <= end; pagenr++)
     {
-        unsigned long pfn = page_to_pfn(info->fb_pages[pagenr].page);
+        unsigned long pfn = page_to_xen_pfn(info->fb_pages[pagenr].page);
         unsigned long mfn = info->fb2m[pagenr];
 
         set_phys_to_machine(pfn, mfn);
@@ -969,7 +970,7 @@ static int xenfb2_remove(struct xenbus_device *dev)
 
 static unsigned long vmalloc_to_mfn(void *p)
 {
-    return pfn_to_mfn(page_to_pfn(vmalloc_to_page(p)));
+    return pfn_to_mfn(page_to_xen_pfn(vmalloc_to_page(p)));
 }
 
 static void xenfb2_init_shared_page(struct xenfb2_info *info,
@@ -981,7 +982,7 @@ static void xenfb2_init_shared_page(struct xenfb2_info *info,
     for (i = 0; i < info->fb_npages; i++) {
         info->fb_pages[i].page = vmalloc_to_page((char *)info->fb + i * PAGE_SIZE);
         info->fb_pages[i].orig_mfn = info->fb2m[i] =
-            pfn_to_mfn(page_to_pfn(info->fb_pages[i].page));
+            pfn_to_mfn(page_to_xen_pfn(info->fb_pages[i].page));
     }
 
     page->in_cons = page->in_prod = 0;
@@ -1034,7 +1035,7 @@ static void xenfb2_backend_changed(struct xenbus_device *dev,
             unsigned int i;
 
             for (i = 0; i < info->fb_npages; i++) {
-                unsigned long pfn = page_to_pfn(info->fb_pages[i].page);
+                unsigned long pfn = page_to_xen_pfn(info->fb_pages[i].page);
                 unsigned long mfn = info->fb_pages[i].orig_mfn;
 
                 info->fb2m[i] = mfn;

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -531,42 +531,6 @@ static void xenfb2_update_dirty(struct xenfb2_info *info)
     wake_up_interruptible(&info->thread_wq);
 }
 
-static void xenfb2_fb_caching(struct xenfb2_info *info,
-                              unsigned long cache_attr)
-{
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33))
-    switch (cache_attr) {
-        case XEN_DOMCTL_MEM_CACHEATTR_UC:
-            info->cache_attr = _PAGE_CACHE_UC;
-            break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WC:
-            info->cache_attr = _PAGE_CACHE_WC;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WT:
-            info->cache_attr = _PAGE_CACHE_WT;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WP:
-            info->cache_attr = _PAGE_CACHE_WP;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WB:
-            info->cache_attr = _PAGE_CACHE_WB;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_UCM:
-            info->cache_attr = _PAGE_CACHE_UC_MINUS;
-                break;
-        default:
-            return;
-    }
-#else
-    printk("xenfb2: xenfb2_fb_caching has been called. This is not supposed to happen\n");
-    printk("xenfb2: Please report this to surfman/xenfb2 developpers.\n");
-#endif
-
-    set_bit(0, &info->thread_flags);
-    wake_up_interruptible(&info->thread_wq);
-}
-
-
 static irqreturn_t xenfb2_event_handler(int rq, void *priv)
 {
     struct xenfb2_info *info = priv;
@@ -596,7 +560,7 @@ static irqreturn_t xenfb2_event_handler(int rq, void *priv)
             xenfb2_update_dirty(info);
             break;
         case XENFB2_TYPE_FB_CACHING:
-            xenfb2_fb_caching(info, event->fb_caching.cache_attr);
+            pr_err("XENFB2_TYPE_FB_CACHING is deprecated.\n");
             break;
         default:
             break;

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -525,26 +525,6 @@ static int xenfb2_thread(void *data)
     return 0;
 }
 
-static void xenfb2_update_fb2m(struct xenfb2_info *info, unsigned int start,
-                               unsigned int end)
-{
-    unsigned int pagenr;
-
-    start = min_t(unsigned int, start, info->fb_size >> PAGE_SHIFT);
-    end = min_t(unsigned int, end, (info->fb_size - 1) >> PAGE_SHIFT);
-
-    for (pagenr = start; pagenr <= end; pagenr++)
-    {
-        unsigned long pfn = page_to_xen_pfn(info->fb_pages[pagenr].page);
-        unsigned long mfn = info->fb2m[pagenr];
-
-        set_phys_to_machine(pfn, mfn);
-    }
-
-    set_bit(0, &info->thread_flags);
-    wake_up_interruptible(&info->thread_wq);
-}
-
 static void xenfb2_update_dirty(struct xenfb2_info *info)
 {
     set_bit(0, &info->thread_flags);
@@ -610,7 +590,7 @@ static irqreturn_t xenfb2_event_handler(int rq, void *priv)
             wake_up_interruptible(&info->checkvar_wait);
             break;
         case XENFB2_TYPE_UPDATE_FB2M:
-            xenfb2_update_fb2m(info, event->update_fb2m.start, event->update_fb2m.end);
+            pr_err("XENFB2_TYPE_UPDATE_FB2M is deprecated.\n");
             break;
         case XENFB2_TYPE_UPDATE_DIRTY:
             xenfb2_update_dirty(info);


### PR DESCRIPTION
See [OXT-1579](https://openxt.atlassian.net/browse/OXT-1579) for more details.

### Refactoring

- Xenfb2 initialization looked a bit confusing. Try to make it easier to read and add some comments. No functional change.
- `xenfb2_set_colreg` was forked from Xenfb upstream, reunite the two. No functional change.
- Minor code changes for clarity.

### Deprecation

`fb2if.h` is not changed for now, instead code is removed and errors are logged when possible should a deprecated interface be used.

- `XENFB2_TYPE_UPDATE_FB2M` has not been used or tested since OpenXT was opened, remove and log an error.
- `XENFB2_TYPE_FB_CACHING` is already deactivated since Linux 2.6, remove and log an error.
- Since `XENFB2_TYPE_UPDATE_FB2M` is no longer used, resetting the framebuffer p2m is not necessary. Remove that logic.

### Work-around

- Remove the dirty-bitmap generation logic (This is a work-around for [OXT-1579](https://openxt.atlassian.net/browse/OXT-1579)).
- `XENFB2_TYPE_DIRTY_READY` will no longer be sent to the backend.