### PR TITLE
OXT-1651, OXT-1652: Load in PVH guest and refactoring.

### DIFF
--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -30,6 +30,7 @@
 #include <asm/xen/page.h>
 #include <xen/events.h>
 #include <xen/page.h>
+#include <xen/platform_pci.h>
 #else
 #include <linux/mm.h>
 #include <asm/page.h>
@@ -1077,20 +1078,14 @@ static struct xenbus_driver xenfb2_driver = {
 
 static int __init xenfb2_init(void)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
-    if (!xen_pv_domain())
-#else
-    if (!is_running_on_xen())
-#endif
+    if (!xen_domain())
         return -ENODEV;
 
-    /* Nothing to do if running in dom0. */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
     if (xen_initial_domain())
-#else
-    if (is_initial_xendomain())
-#endif
-	return -ENODEV;
+        return -ENODEV;
+
+    if (!xen_has_pv_devices())
+        return -ENODEV;
 
     return xenbus_register_frontend(&xenfb2_driver);
 }

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -29,6 +29,7 @@
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,33))
 #include <asm/xen/page.h>
 #include <xen/events.h>
+#include <xen/page.h>
 #else
 #include <linux/mm.h>
 #include <asm/page.h>
@@ -533,7 +534,7 @@ static void xenfb2_update_fb2m(struct xenfb2_info *info, unsigned int start,
 
     for (pagenr = start; pagenr <= end; pagenr++)
     {
-        unsigned long pfn = page_to_pfn(info->fb_pages[pagenr].page);
+        unsigned long pfn = page_to_xen_pfn(info->fb_pages[pagenr].page);
         unsigned long mfn = info->fb2m[pagenr];
 
         set_phys_to_machine(pfn, mfn);
@@ -969,7 +970,7 @@ static int xenfb2_remove(struct xenbus_device *dev)
 
 static unsigned long vmalloc_to_mfn(void *p)
 {
-    return pfn_to_mfn(page_to_pfn(vmalloc_to_page(p)));
+    return pfn_to_mfn(page_to_xen_pfn(vmalloc_to_page(p)));
 }
 
 static void xenfb2_init_shared_page(struct xenfb2_info *info,
@@ -981,7 +982,7 @@ static void xenfb2_init_shared_page(struct xenfb2_info *info,
     for (i = 0; i < info->fb_npages; i++) {
         info->fb_pages[i].page = vmalloc_to_page((char *)info->fb + i * PAGE_SIZE);
         info->fb_pages[i].orig_mfn = info->fb2m[i] =
-            pfn_to_mfn(page_to_pfn(info->fb_pages[i].page));
+            pfn_to_mfn(page_to_xen_pfn(info->fb_pages[i].page));
     }
 
     page->in_cons = page->in_prod = 0;
@@ -1034,7 +1035,7 @@ static void xenfb2_backend_changed(struct xenbus_device *dev,
             unsigned int i;
 
             for (i = 0; i < info->fb_npages; i++) {
-                unsigned long pfn = page_to_pfn(info->fb_pages[i].page);
+                unsigned long pfn = page_to_xen_pfn(info->fb_pages[i].page);
                 unsigned long mfn = info->fb_pages[i].orig_mfn;
 
                 info->fb2m[i] = mfn;

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -531,42 +531,6 @@ static void xenfb2_update_dirty(struct xenfb2_info *info)
     wake_up_interruptible(&info->thread_wq);
 }
 
-static void xenfb2_fb_caching(struct xenfb2_info *info,
-                              unsigned long cache_attr)
-{
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33))
-    switch (cache_attr) {
-        case XEN_DOMCTL_MEM_CACHEATTR_UC:
-            info->cache_attr = _PAGE_CACHE_UC;
-            break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WC:
-            info->cache_attr = _PAGE_CACHE_WC;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WT:
-            info->cache_attr = _PAGE_CACHE_WT;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WP:
-            info->cache_attr = _PAGE_CACHE_WP;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_WB:
-            info->cache_attr = _PAGE_CACHE_WB;
-                break;
-        case XEN_DOMCTL_MEM_CACHEATTR_UCM:
-            info->cache_attr = _PAGE_CACHE_UC_MINUS;
-                break;
-        default:
-            return;
-    }
-#else
-    printk("xenfb2: xenfb2_fb_caching has been called. This is not supposed to happen\n");
-    printk("xenfb2: Please report this to surfman/xenfb2 developpers.\n");
-#endif
-
-    set_bit(0, &info->thread_flags);
-    wake_up_interruptible(&info->thread_wq);
-}
-
-
 static irqreturn_t xenfb2_event_handler(int rq, void *priv)
 {
     struct xenfb2_info *info = priv;
@@ -596,7 +560,7 @@ static irqreturn_t xenfb2_event_handler(int rq, void *priv)
             xenfb2_update_dirty(info);
             break;
         case XENFB2_TYPE_FB_CACHING:
-            xenfb2_fb_caching(info, event->fb_caching.cache_attr);
+            pr_err("XENFB2_TYPE_FB_CACHING is deprecated.\n");
             break;
         default:
             break;

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -525,26 +525,6 @@ static int xenfb2_thread(void *data)
     return 0;
 }
 
-static void xenfb2_update_fb2m(struct xenfb2_info *info, unsigned int start,
-                               unsigned int end)
-{
-    unsigned int pagenr;
-
-    start = min_t(unsigned int, start, info->fb_size >> PAGE_SHIFT);
-    end = min_t(unsigned int, end, (info->fb_size - 1) >> PAGE_SHIFT);
-
-    for (pagenr = start; pagenr <= end; pagenr++)
-    {
-        unsigned long pfn = page_to_xen_pfn(info->fb_pages[pagenr].page);
-        unsigned long mfn = info->fb2m[pagenr];
-
-        set_phys_to_machine(pfn, mfn);
-    }
-
-    set_bit(0, &info->thread_flags);
-    wake_up_interruptible(&info->thread_wq);
-}
-
 static void xenfb2_update_dirty(struct xenfb2_info *info)
 {
     set_bit(0, &info->thread_flags);
@@ -610,7 +590,7 @@ static irqreturn_t xenfb2_event_handler(int rq, void *priv)
             wake_up_interruptible(&info->checkvar_wait);
             break;
         case XENFB2_TYPE_UPDATE_FB2M:
-            xenfb2_update_fb2m(info, event->update_fb2m.start, event->update_fb2m.end);
+            pr_err("XENFB2_TYPE_UPDATE_FB2M is deprecated.\n");
             break;
         case XENFB2_TYPE_UPDATE_DIRTY:
             xenfb2_update_dirty(info);

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -229,9 +229,9 @@ static int xenfb2_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
     struct xenfb2_mapping *map = vma->vm_private_data;
     struct xenfb2_info *info = map->info;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
-    int pgnr = ((long)vmf->address - vma->vm_start) >> PAGE_SHIFT;
+    int pgnr = (vmf->address - vma->vm_start) >> PAGE_SHIFT;
 #else
-    int pgnr = ((long)vmf->virtual_address - vma->vm_start) >> PAGE_SHIFT;
+    int pgnr = (vmf->virtual_address - vma->vm_start) >> PAGE_SHIFT;
 #endif
     struct page *page;
 

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -849,7 +849,7 @@ xenfb2_probe(struct xenbus_device *dev,
 
     ret = register_framebuffer(fb_info);
     if (ret) {
-        fb_dealloc_cmap(&info->fb_info->cmap);
+        fb_dealloc_cmap(&fb_info->cmap);
         framebuffer_release(fb_info);
         xenbus_dev_fatal(dev, ret, "register_framebuffer");
         goto fail;

--- a/linux/xenfb2.c
+++ b/linux/xenfb2.c
@@ -413,20 +413,23 @@ static int xenfb2_setcolreg(unsigned regno, unsigned red, unsigned green,
     if (regno > info->cmap.len)
         return 1;
 
-    red >>= (16 - info->var.red.length);
-    green >>= (16 - info->var.green.length);
-    blue >>= (16 - info->var.blue.length);
+#define CNVT_TOHW(val, width) ((((val)<<(width))+0x7FFF-(val))>>16)
+    red = CNVT_TOHW(red, info->var.red.length);
+    green = CNVT_TOHW(green, info->var.green.length);
+    blue = CNVT_TOHW(blue, info->var.blue.length);
+    transp = CNVT_TOHW(transp, info->var.transp.length);
+#undef CNVT_TOHW
 
     v = (red << info->var.red.offset) |
         (green << info->var.green.offset) |
         (blue << info->var.blue.offset);
 
     switch (info->var.bits_per_pixel) {
-    case 16:
-    case 24:
-    case 32:
-	((u32 *)info->pseudo_palette)[regno] = v;
-	break;
+        case 16:
+        case 24:
+        case 32:
+            ((u32 *)info->pseudo_palette)[regno] = v;
+            break;
     }
 
     return 0;


### PR DESCRIPTION
- Let Xenfb2 load in a PVH guest (OXT-1651).
- Remove logic for deprecated interfaces that are no longer exercised by Surfman.
- Refactor some portion of the driver to honor interfaces or improve clarity.
- Rebase function taken from upstream a while back.
- Fix a bug in the error handling.