### PR TITLE
module: Refresh the Makefile

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,44 +1,24 @@
-#
-# Copyright (c) 2011 Citrix Systems, Inc.
-# 
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-#
-
 ifneq ($(KERNELRELEASE),)
+# kbuild part of makefile
 include Kbuild
+
 else
+# normal makefile
+KERNEL_VERSION ?= `uname -r`
+KERNEL_SRC ?= /lib/modules/$(KERNEL_VERSION)/build
+INSTALL_HDR_PATH ?= /usr
 
-KERNELDIR ?= /lib/modules/`uname -r`/build
-PREFIX ?= /usr
-
-all::
-	$(MAKE) -C $(KERNELDIR) M=`pwd` $@
-
-modules:
-	$(MAKE) -C $(KERNELDIR) M=`pwd` modules
+default:
+	$(MAKE) -C $(KERNEL_SRC) M=$$PWD
 
 clean:
-	$(MAKE) -C $(KERNELDIR) M=`pwd` clean
-	rm -f Makefile.xen
+	$(MAKE) -C $(KERNEL_SRC) M=$$PWD clean
 
 modules_install:
-	$(MAKE) -C $(KERNELDIR) M=`pwd` modules_install
+	$(MAKE) -C $(KERNEL_SRC) M=$$PWD modules_install
 
-install:
-	install -m 0755 -d $(PREFIX)/include
-	install -m 0644 fb2if.h $(PREFIX)/include
-
+headers_install:
+	install -m 0755 -d $(INSTALL_HDR_PATH)/include
+	install -m 0644 fb2if.h $(INSTALL_HDR_PATH)/include
 
 endif


### PR DESCRIPTION
Follow the recommendations from the kernel documentation to write an
out-of-tree module Makefile. One noticeable difference is OE
module.bbclass uses KERNEL_SRC instead of KDIR. Since this is intended
for OE, use the former.

https://www.kernel.org/doc/html/latest/kbuild/modules.html
https://www.kernel.org/doc/html/latest/kbuild/kbuild.html?highlight=install_hdr_path#install-hdr-path

#### Depends on:
- https://github.com/OpenXT/xenclient-oe/pull/1318
